### PR TITLE
Support spaces in the directory path

### DIFF
--- a/editvault.sh
+++ b/editvault.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-docker run -it -v $(pwd):/project -v ~/.aws:/root/.aws -e TARGET_ENV=$1 simplemachines/ansible-template:latest scripts/editvault.sh
+docker run -it -v "$(pwd):/project" -v ~/.aws:/root/.aws -e TARGET_ENV=$1 simplemachines/ansible-template:latest scripts/editvault.sh

--- a/run-playbook.sh
+++ b/run-playbook.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-docker run -it -v $(pwd):/project -v ~/.aws:/root/.aws -e DEPLOY_CONFIG=$1 simplemachines/ansible-template:latest scripts/run-playbook.sh
+docker run -it -v "$(pwd):/project" -v ~/.aws:/root/.aws -e DEPLOY_CONFIG=$1 simplemachines/ansible-template:latest scripts/run-playbook.sh


### PR DESCRIPTION
Encapsulate the $(pwd) in the editvault and run-playbook scripts in quotes so it works when you are calling it from a directory path with spaces in it.

Fixes Issue #42 